### PR TITLE
Give linter more Git history and a manual trigger

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,18 +10,21 @@ on:
   push:
     branches-ignore:
       - 'main'
+  # Run when manually triggered
+  workflow_dispatch:
 
 jobs:
   build:
-    # Name the Job
     name: Lint Code Base
-    # Set the agent to run on
     runs-on: ubuntu-latest
 
     steps:
       # Checkout code base
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
 
       # Run Linter against code base
       - name: Lint Code Base


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD026 -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pull a `linter.yml` change into the template, that I've made manually in a few places:

Give **actions/checkout@v2** a `with:` clause that specifies `fetch_depth: 0`, so full history will be available for **github/super-linter**.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
**actions/checkout@v2** default fetch depth is `0`. When `VALIDATE_ALL_CODEBASE` is `false`, **super-linter** needs more Git history.

The manual trigger is for convenience, so the linter can be run manually. I'm not sure this is necessary, or even useful, but I keep thinking it should be there so I added it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, I guess?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
n/a

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
n/a
