### PR TITLE
Prevent duplicate template sync PRs

### DIFF
--- a/.github/workflows/sync-from-template.yml
+++ b/.github/workflows/sync-from-template.yml
@@ -46,6 +46,8 @@ jobs:
             
             Please review changes carefully before merging.
           pr_labels: template-sync,automated
+          is_pr_cleanup: "true"
+          is_force_push_pr: "true"
 
       - name: Surface common failure causes
         if: failure() && steps.sync.conclusion == 'failure'


### PR DESCRIPTION
Enable is_pr_cleanup and is_force_push_pr on the
AndreasAugustin/actions-template-sync@v2 step so re-runs update the
existing sync PR instead of opening a new one for each new template
commit hash.

Fixes #7

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
